### PR TITLE
fixed bug with saving state by tracking usernames instead of all user data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <dpp/dpp.h>
-#include <cstdlib>
 #include <string>
 #include <optional>
 #include <memory>
+#include <thread>
 #include "states/user_state.h"
 #include "commands/set_info.h"
 #include "states/state_manager.h"
@@ -27,14 +27,15 @@ int main()
         std::cout << "Starting bot\n";
         std::shared_ptr<User_state> user_state = std::make_shared<User_state>();
         std::unique_ptr<State_manager> state_manager = std::make_unique<State_manager>(60, user_state);
-        state_manager->start();
+        std::thread t([&state_manager]()
+                      { state_manager->start(); });
         bot.on_slashcommand([&user_state](const dpp::slashcommand_t event)
                             {
         dpp::user user = event.command.get_issuing_user();
 		if (event.command.get_command_name() == "setpayment") {
             std::string payment_info = std::get<std::string>(event.get_parameter("payment_info"));
             Set_info::set_info(std::move(user_state), user, payment_info);
-            event.reply("Payment details set for " + (user.username) + "to:\n" + payment_info);
+            event.reply("Payment details set for " + (user.username) + " to:\n" + payment_info);
         } });
 
         bot.on_ready([&bot](auto event)
@@ -42,7 +43,7 @@ int main()
 		if (dpp::run_once<struct register_bot_commands>()) {
             dpp::slashcommand setpayment = dpp::slashcommand("setpayment", "Set payment details for yourself", bot.me.id);
             setpayment.add_option(dpp::command_option(dpp::co_string, "payment_info", "payment_details", true));
-            bot.global_command_create(setpayment);
+            bot.global_bulk_command_create({setpayment});
         } });
 
         bot.start(dpp::st_wait);

--- a/src/states/state_manager.cpp
+++ b/src/states/state_manager.cpp
@@ -4,6 +4,7 @@ extern std::shared_ptr<User_state> user_state;
 State_manager::State_manager(int _save_interval_seconds, std::shared_ptr<User_state> _user_state) : save_interval_seconds(_save_interval_seconds), user_state(_user_state) {}
 void State_manager::start()
 {
+    std::this_thread::sleep_for(std::chrono::seconds(save_interval_seconds));
     while (true)
     {
         user_state->save();

--- a/src/states/user_state.h
+++ b/src/states/user_state.h
@@ -24,7 +24,7 @@ public:
 private:
     std::string state_file = "user_state.txt";
 
-    std::map<dpp::user, std::string, std::function<bool(const dpp::user &, const dpp::user &)>> user_to_info;
+    std::map<std::string, std::string> user_to_info;
 
     void write(nlohmann::json json);
 


### PR DESCRIPTION
This also works better because username is the only unique field, so using all data would create multiple copies of users (if they changed avatar, enabled mfa etc).